### PR TITLE
Modify role for events

### DIFF
--- a/core/rbac/roles.yaml
+++ b/core/rbac/roles.yaml
@@ -22,6 +22,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 ---
 # This role enables reading metrics
 kind: ClusterRole


### PR DESCRIPTION
Current RBAC for events do not work. Currently, the creation of events is rejected. This PR allows Iter8 to create events associated with Experiments.  Fixes https://github.com/iter8-tools/etc3/issues/192